### PR TITLE
Switch to dynamic memory allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 lib_name = libzbxhaproxy.so
 lib_dir = /usr/local/lib
 zbx_include = /home/user/zabbix/include
-gcc_com_options = -std=gnu11 -fPIC -w -lm
+gcc_com_options = -std=gnu11 -fPIC -Wall -lm
 gcc = gcc $(gcc_com_options) -c
 build = ./build
 src = ./src

--- a/src/haproxy_servers.c
+++ b/src/haproxy_servers.c
@@ -109,7 +109,6 @@ haproxy_servers_t update_haproxy_servers(haproxy_servers_t servers, haproxy_serv
     pxname = server->stat;
     svname = server->stat + server->offsets[1];
     prev = get_prev_haproxy_server(servers, pxname, svname);
-    
     if (prev->next != NULL) {
         // replace exists server in list
         server->next = prev->next->next;
@@ -119,6 +118,6 @@ haproxy_servers_t update_haproxy_servers(haproxy_servers_t servers, haproxy_serv
         // insert new server in list
         prev->next = server;
     }
-    
+
     return servers;
 }

--- a/src/haproxy_servers.h
+++ b/src/haproxy_servers.h
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 // max number of haproxy metrics
 #define MAX_NUM_METRICS 100
@@ -36,7 +37,7 @@ typedef enum {
     frontend,
     backend,
     server,
-    listener        
+    listener
 } haproxy_server_type_t;
 
 int check_haproxy_server_name(haproxy_server_t* server, char* pxname, char* svname);

--- a/src/haproxy_stat.h
+++ b/src/haproxy_stat.h
@@ -16,9 +16,10 @@
 #include <stdio.h>
 #include <time.h>
 #include <errno.h>
+#include <unistd.h>
+#include <assert.h>
 #include "hash_table.h"
 #include "haproxy_servers.h"
-
 
 #define CACHE_TTL 30
 #define HAPROXY_NO_DATA ""
@@ -26,10 +27,8 @@
 #define HAPROXY_FAIL -1
 #define MAX_NUM_METRICS 100
 #define MAX_RETRIES 2
-#define RECV_BUFFER_SIZE 8192
 
 int haproxy_socket_fd;
-char recv_buffer[RECV_BUFFER_SIZE];
 time_t stat_timestamp;
 time_t info_timestamp;
 ht_hash_table* haproxy_info;
@@ -48,7 +47,7 @@ char* haproxy_info_value(char* name);
 void haproxy_parse_info(char* s);
 void haproxy_parse_stat(char* s);
 void haproxy_parse_metrics(char* s);
-int haproxy_recv(char* buffer, size_t size);
+int haproxy_recv(char **ret_data);
 int haproxy_update_info(char* socket);
 int haproxy_update_stat(char* socket);
 

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -12,6 +12,16 @@ int HT_INITIAL_BASE_SIZE = 151;
 int HT_PRIME_1 = 151;
 int HT_PRIME_2 = 163;
 static ht_item HT_DELETED_ITEM = {NULL, NULL};
+static ht_item* ht_new_item(const char* k, const char* v);
+static ht_hash_table* ht_new_sized(const int base_size);
+static void ht_del_item(ht_item* item);
+static int ht_hash(const char* s, const int a, const int m);
+static int ht_get_hash(const char* s, const int num_buckets, const int attempt);
+static void ht_resize(ht_hash_table* ht, const int base_size);
+static void ht_resize_up(ht_hash_table* ht);
+static void ht_resize_down(ht_hash_table* ht);
+
+
 
 static ht_item* ht_new_item(const char* k, const char* v)
 {

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -27,18 +27,9 @@ typedef struct
     ht_item** items;
 } ht_hash_table;
 
-static ht_item* ht_new_item(const char* k, const char* v);
 ht_hash_table* ht_new();
-static ht_hash_table* ht_new_sized(const int base_size);
-static void ht_del_item(ht_item* item);
 void ht_del_hash_table(ht_hash_table* hashtable);
-static int ht_hash(const char* s, const int a, const int m);
-static int ht_get_hash(const char* s, const int num_buckets, const int attempt);
-
 void ht_insert(ht_hash_table* ht, const char* key, const char* value);
 char* ht_search(ht_hash_table* ht, const char* key);
 void ht_delete(ht_hash_table* h, const char* key);
-static void ht_resize(ht_hash_table* ht, const int base_size);
-static void ht_resize_up(ht_hash_table* ht);
-static void ht_resize_down(ht_hash_table* ht);
 #endif //HASH_TABLES_IN_C_HAST_TABLE_H

--- a/src/zbxhaproxy.c
+++ b/src/zbxhaproxy.c
@@ -21,12 +21,12 @@ ZBX_METRIC *zbx_module_item_list(void) {
 int zbx_module_init(void) {
     zabbix_log(LOG_LEVEL_INFORMATION, "starting agent module %s", HAPROXY_MOD_NAME);
     haproxy_init();
-    
+
     return SYSINFO_RET_OK;
 }
 
 int zbx_module_uninit(void) {
-    haproxy_uninit();    
+    haproxy_uninit();
     return SYSINFO_RET_OK;
 }
 
@@ -87,7 +87,6 @@ static int zbxhaproxy_discovery(AGENT_REQUEST *request, AGENT_RESULT *result) {
     data = haproxy_discovery(socket);
     zabbix_log(LOG_LEVEL_DEBUG, "module %s response: %s", HAPROXY_MOD_NAME, data);
     SET_STR_RESULT(result, data);
-    
     return SYSINFO_RET_OK;
 }
 


### PR DESCRIPTION
- Added dynamic memory allocation for zabbix reponse data and reading from socket.
- Enable -Wall in Makefile, fixed all warnings
- Several other optimizations.

Tested against zabbix 4.4 on Ubuntu 18.04

Original solution with static allocation did not work with haproxy on openstack due to the number of backends and the size of response (avg 26k)